### PR TITLE
Java: support variant names different from class names, fix imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-codegen"
 description = "Generate code from JSON Typedef schemas"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 authors = ["Ulysse Carion <ulysse@segment.com>"]
 edition = "2018"

--- a/integration_tests/go/gamut/index.go
+++ b/integration_tests/go/gamut/index.go
@@ -1,9 +1,9 @@
 package gamut
 
 
-import "time"
-
 import "encoding/json"
+
+import "time"
 
 
 

--- a/integration_tests/java/boolean/Boolean.java
+++ b/integration_tests/java/boolean/Boolean.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Boolean {

--- a/integration_tests/java/discriminator/Discriminator.java
+++ b/integration_tests/java/discriminator/Discriminator.java
@@ -1,14 +1,20 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "version")
   @JsonSubTypes({
     
-      @JsonSubTypes.Type(V2.class),
+      @JsonSubTypes.Type(name = "v2", value = V2.class),
     
-      @JsonSubTypes.Type(V1.class),
+      @JsonSubTypes.Type(name = "v1", value = V1.class),
     
   })
 

--- a/integration_tests/java/discriminator/V1.java
+++ b/integration_tests/java/discriminator/V1.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class V1 extends Discriminator {

--- a/integration_tests/java/discriminator/V1User.java
+++ b/integration_tests/java/discriminator/V1User.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class V1User {

--- a/integration_tests/java/discriminator/V2.java
+++ b/integration_tests/java/discriminator/V2.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class V2 extends Discriminator {

--- a/integration_tests/java/discriminator/V2User.java
+++ b/integration_tests/java/discriminator/V2User.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class V2User {

--- a/integration_tests/java/elements/Elements.java
+++ b/integration_tests/java/elements/Elements.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Elements {

--- a/integration_tests/java/empty/Empty.java
+++ b/integration_tests/java/empty/Empty.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Empty {

--- a/integration_tests/java/enum/Enum.java
+++ b/integration_tests/java/enum/Enum.java
@@ -2,11 +2,11 @@ package com.jsontypedef.jtdcodegendemo;
 
 public enum Enum {
 
-  @JsonProperty("foo")
-  FOO,
-
   @JsonProperty("baz")
   BAZ,
+
+  @JsonProperty("foo")
+  FOO,
 
   @JsonProperty("bar")
   BAR,

--- a/integration_tests/java/float32/Float32.java
+++ b/integration_tests/java/float32/Float32.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Float32 {

--- a/integration_tests/java/float64/Float64.java
+++ b/integration_tests/java/float64/Float64.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Float64 {

--- a/integration_tests/java/gamut/Discriminator.java
+++ b/integration_tests/java/gamut/Discriminator.java
@@ -1,14 +1,20 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "foo")
   @JsonSubTypes({
     
-      @JsonSubTypes.Type(DiscriminatorBaz.class),
+      @JsonSubTypes.Type(name = "bar", value = DiscriminatorBar.class),
     
-      @JsonSubTypes.Type(DiscriminatorBar.class),
+      @JsonSubTypes.Type(name = "baz", value = DiscriminatorBaz.class),
     
   })
 

--- a/integration_tests/java/gamut/DiscriminatorBar.java
+++ b/integration_tests/java/gamut/DiscriminatorBar.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class DiscriminatorBar extends Discriminator {

--- a/integration_tests/java/gamut/DiscriminatorBaz.java
+++ b/integration_tests/java/gamut/DiscriminatorBaz.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class DiscriminatorBaz extends Discriminator {

--- a/integration_tests/java/gamut/Element.java
+++ b/integration_tests/java/gamut/Element.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Element {

--- a/integration_tests/java/gamut/Elements.java
+++ b/integration_tests/java/gamut/Elements.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Elements {

--- a/integration_tests/java/gamut/Empty.java
+++ b/integration_tests/java/gamut/Empty.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Empty {

--- a/integration_tests/java/gamut/Gamut.java
+++ b/integration_tests/java/gamut/Gamut.java
@@ -1,9 +1,19 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Gamut {
+
+  
+  @JsonProperty("empty")
+  private Empty empty;
 
   
   @JsonProperty("values")
@@ -14,16 +24,12 @@ public class Gamut {
   private Elements elements;
 
   
-  @JsonProperty("type")
-  private Type type;
-
-  
   @JsonProperty("discriminator")
   private Discriminator discriminator;
 
   
-  @JsonProperty("empty")
-  private Empty empty;
+  @JsonProperty("type")
+  private Type type;
 
   
   @JsonProperty("enum")
@@ -35,6 +41,14 @@ public class Gamut {
   }
   
 
+
+  public Empty getEmpty() {
+    return empty;
+  }
+
+  public void setEmpty(Empty empty) {
+    this.empty = empty;
+  }
 
   public Values getValues() {
     return values;
@@ -52,14 +66,6 @@ public class Gamut {
     this.elements = elements;
   }
 
-  public Type getType() {
-    return type;
-  }
-
-  public void setType(Type type) {
-    this.type = type;
-  }
-
   public Discriminator getDiscriminator() {
     return discriminator;
   }
@@ -68,12 +74,12 @@ public class Gamut {
     this.discriminator = discriminator;
   }
 
-  public Empty getEmpty() {
-    return empty;
+  public Type getType() {
+    return type;
   }
 
-  public void setEmpty(Empty empty) {
-    this.empty = empty;
+  public void setType(Type type) {
+    this.type = type;
   }
 
   public Enum getEnum() {

--- a/integration_tests/java/gamut/Type.java
+++ b/integration_tests/java/gamut/Type.java
@@ -1,53 +1,59 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Type {
-
-  
-  @JsonProperty("uint32")
-  private Integer uint32;
-
-  
-  @JsonProperty("uint16")
-  private Short uint16;
-
-  
-  @JsonProperty("float32")
-  private Float float32;
 
   
   @JsonProperty("int8")
   private Byte int8;
 
   
-  @JsonProperty("uint8")
-  private Byte uint8;
+  @JsonProperty("timestamp")
+  private OffsetDateTime timestamp;
 
   
   @JsonProperty("int16")
   private Short int16;
 
   
-  @JsonProperty("timestamp")
-  private OffsetDateTime timestamp;
-
-  
-  @JsonProperty("string")
-  private String string;
+  @JsonProperty("uint32")
+  private Integer uint32;
 
   
   @JsonProperty("int32")
   private Integer int32;
 
   
+  @JsonProperty("float64")
+  private Double float64;
+
+  
+  @JsonProperty("uint16")
+  private Short uint16;
+
+  
   @JsonProperty("boolean")
   private Boolean boolean;
 
   
-  @JsonProperty("float64")
-  private Double float64;
+  @JsonProperty("string")
+  private String string;
+
+  
+  @JsonProperty("float32")
+  private Float float32;
+
+  
+  @JsonProperty("uint8")
+  private Byte uint8;
 
 
   
@@ -56,52 +62,12 @@ public class Type {
   
 
 
-  public Integer getUint32() {
-    return uint32;
-  }
-
-  public void setUint32(Integer uint32) {
-    this.uint32 = uint32;
-  }
-
-  public Short getUint16() {
-    return uint16;
-  }
-
-  public void setUint16(Short uint16) {
-    this.uint16 = uint16;
-  }
-
-  public Float getFloat32() {
-    return float32;
-  }
-
-  public void setFloat32(Float float32) {
-    this.float32 = float32;
-  }
-
   public Byte getInt8() {
     return int8;
   }
 
   public void setInt8(Byte int8) {
     this.int8 = int8;
-  }
-
-  public Byte getUint8() {
-    return uint8;
-  }
-
-  public void setUint8(Byte uint8) {
-    this.uint8 = uint8;
-  }
-
-  public Short getInt16() {
-    return int16;
-  }
-
-  public void setInt16(Short int16) {
-    this.int16 = int16;
   }
 
   public OffsetDateTime getTimestamp() {
@@ -112,12 +78,20 @@ public class Type {
     this.timestamp = timestamp;
   }
 
-  public String getString() {
-    return string;
+  public Short getInt16() {
+    return int16;
   }
 
-  public void setString(String string) {
-    this.string = string;
+  public void setInt16(Short int16) {
+    this.int16 = int16;
+  }
+
+  public Integer getUint32() {
+    return uint32;
+  }
+
+  public void setUint32(Integer uint32) {
+    this.uint32 = uint32;
   }
 
   public Integer getInt32() {
@@ -128,6 +102,22 @@ public class Type {
     this.int32 = int32;
   }
 
+  public Double getFloat64() {
+    return float64;
+  }
+
+  public void setFloat64(Double float64) {
+    this.float64 = float64;
+  }
+
+  public Short getUint16() {
+    return uint16;
+  }
+
+  public void setUint16(Short uint16) {
+    this.uint16 = uint16;
+  }
+
   public Boolean getBoolean() {
     return boolean;
   }
@@ -136,12 +126,28 @@ public class Type {
     this.boolean = boolean;
   }
 
-  public Double getFloat64() {
-    return float64;
+  public String getString() {
+    return string;
   }
 
-  public void setFloat64(Double float64) {
-    this.float64 = float64;
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  public Float getFloat32() {
+    return float32;
+  }
+
+  public void setFloat32(Float float32) {
+    this.float32 = float32;
+  }
+
+  public Byte getUint8() {
+    return uint8;
+  }
+
+  public void setUint8(Byte uint8) {
+    this.uint8 = uint8;
   }
 
 }

--- a/integration_tests/java/gamut/Value.java
+++ b/integration_tests/java/gamut/Value.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Value {

--- a/integration_tests/java/gamut/Values.java
+++ b/integration_tests/java/gamut/Values.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Values {

--- a/integration_tests/java/int16/Int16.java
+++ b/integration_tests/java/int16/Int16.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Int16 {

--- a/integration_tests/java/int32/Int32.java
+++ b/integration_tests/java/int32/Int32.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Int32 {

--- a/integration_tests/java/int8/Int8.java
+++ b/integration_tests/java/int8/Int8.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Int8 {

--- a/integration_tests/java/nullable_boolean/NullableBoolean.java
+++ b/integration_tests/java/nullable_boolean/NullableBoolean.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class NullableBoolean {

--- a/integration_tests/java/properties/D.java
+++ b/integration_tests/java/properties/D.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class D {

--- a/integration_tests/java/properties/Properties.java
+++ b/integration_tests/java/properties/Properties.java
@@ -1,25 +1,31 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Properties {
-
-  
-  @JsonProperty("b")
-  private OffsetDateTime b;
 
   
   @JsonProperty("a")
   private String a;
 
   
-  @JsonProperty("c")
-  private String c;
+  @JsonProperty("b")
+  private OffsetDateTime b;
 
   
   @JsonProperty("d")
   private D d;
+
+  
+  @JsonProperty("c")
+  private String c;
 
 
   
@@ -27,14 +33,6 @@ public class Properties {
   }
   
 
-
-  public OffsetDateTime getB() {
-    return b;
-  }
-
-  public void setB(OffsetDateTime b) {
-    this.b = b;
-  }
 
   public String getA() {
     return a;
@@ -44,12 +42,12 @@ public class Properties {
     this.a = a;
   }
 
-  public String getC() {
-    return c;
+  public OffsetDateTime getB() {
+    return b;
   }
 
-  public void setC(String c) {
-    this.c = c;
+  public void setB(OffsetDateTime b) {
+    this.b = b;
   }
 
   public D getD() {
@@ -58,6 +56,14 @@ public class Properties {
 
   public void setD(D d) {
     this.d = d;
+  }
+
+  public String getC() {
+    return c;
+  }
+
+  public void setC(String c) {
+    this.c = c;
   }
 
 }

--- a/integration_tests/java/ref/Bar.java
+++ b/integration_tests/java/ref/Bar.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Bar {

--- a/integration_tests/java/ref/Foo.java
+++ b/integration_tests/java/ref/Foo.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Foo {

--- a/integration_tests/java/ref/Ref.java
+++ b/integration_tests/java/ref/Ref.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Ref {

--- a/integration_tests/java/string/String.java
+++ b/integration_tests/java/string/String.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class String {

--- a/integration_tests/java/timestamp/Timestamp.java
+++ b/integration_tests/java/timestamp/Timestamp.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Timestamp {

--- a/integration_tests/java/uint16/Uint16.java
+++ b/integration_tests/java/uint16/Uint16.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Uint16 {

--- a/integration_tests/java/uint32/Uint32.java
+++ b/integration_tests/java/uint32/Uint32.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Uint32 {

--- a/integration_tests/java/uint8/Uint8.java
+++ b/integration_tests/java/uint8/Uint8.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Uint8 {

--- a/integration_tests/java/user/Location.java
+++ b/integration_tests/java/user/Location.java
@@ -1,17 +1,23 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Location {
 
   
-  @JsonProperty("lat")
-  private String lat;
-
-  
   @JsonProperty("lng")
   private String lng;
+
+  
+  @JsonProperty("lat")
+  private String lat;
 
 
   
@@ -20,20 +26,20 @@ public class Location {
   
 
 
-  public String getLat() {
-    return lat;
-  }
-
-  public void setLat(String lat) {
-    this.lat = lat;
-  }
-
   public String getLng() {
     return lng;
   }
 
   public void setLng(String lng) {
     this.lng = lng;
+  }
+
+  public String getLat() {
+    return lat;
+  }
+
+  public void setLat(String lat) {
+    this.lat = lat;
   }
 
 }

--- a/integration_tests/java/user/Name.java
+++ b/integration_tests/java/user/Name.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Name {

--- a/integration_tests/java/user/Preferences.java
+++ b/integration_tests/java/user/Preferences.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Preferences {

--- a/integration_tests/java/user/PreferencesDoNotTrack.java
+++ b/integration_tests/java/user/PreferencesDoNotTrack.java
@@ -1,14 +1,20 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "version")
   @JsonSubTypes({
     
-      @JsonSubTypes.Type(PreferencesDoNotTrackV0.class),
+      @JsonSubTypes.Type(name = "v0", value = PreferencesDoNotTrackV0.class),
     
-      @JsonSubTypes.Type(PreferencesDoNotTrackV1.class),
+      @JsonSubTypes.Type(name = "v1", value = PreferencesDoNotTrackV1.class),
     
   })
 

--- a/integration_tests/java/user/PreferencesDoNotTrackV0.java
+++ b/integration_tests/java/user/PreferencesDoNotTrackV0.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class PreferencesDoNotTrackV0 extends PreferencesDoNotTrack {

--- a/integration_tests/java/user/PreferencesDoNotTrackV1.java
+++ b/integration_tests/java/user/PreferencesDoNotTrackV1.java
@@ -1,17 +1,23 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class PreferencesDoNotTrackV1 extends PreferencesDoNotTrack {
 
   
-  @JsonProperty("do_not_track")
-  private PreferencesDoNotTrackV1DoNotTrack doNotTrack;
-
-  
   @JsonProperty("opt_out_channels")
   private List<String> optOutChannels;
+
+  
+  @JsonProperty("do_not_track")
+  private PreferencesDoNotTrackV1DoNotTrack doNotTrack;
 
 
   
@@ -20,20 +26,20 @@ public class PreferencesDoNotTrackV1 extends PreferencesDoNotTrack {
   
 
 
-  public PreferencesDoNotTrackV1DoNotTrack getDoNotTrack() {
-    return doNotTrack;
-  }
-
-  public void setDoNotTrack(PreferencesDoNotTrackV1DoNotTrack doNotTrack) {
-    this.doNotTrack = doNotTrack;
-  }
-
   public List<String> getOptOutChannels() {
     return optOutChannels;
   }
 
   public void setOptOutChannels(List<String> optOutChannels) {
     this.optOutChannels = optOutChannels;
+  }
+
+  public PreferencesDoNotTrackV1DoNotTrack getDoNotTrack() {
+    return doNotTrack;
+  }
+
+  public void setDoNotTrack(PreferencesDoNotTrackV1DoNotTrack doNotTrack) {
+    this.doNotTrack = doNotTrack;
   }
 
 }

--- a/integration_tests/java/user/PreferencesDoNotTrackV1DoNotTrack.java
+++ b/integration_tests/java/user/PreferencesDoNotTrackV1DoNotTrack.java
@@ -2,13 +2,13 @@ package com.jsontypedef.jtdcodegendemo;
 
 public enum PreferencesDoNotTrackV1DoNotTrack {
 
-  @JsonProperty("NONE")
-  NONE,
+  @JsonProperty("ALL")
+  ALL,
 
   @JsonProperty("ESSENTIAL_ONLY")
   ESSENTIAL_ONLY,
 
-  @JsonProperty("ALL")
-  ALL,
+  @JsonProperty("NONE")
+  NONE,
 
 }

--- a/integration_tests/java/user/PreferencesTitle.java
+++ b/integration_tests/java/user/PreferencesTitle.java
@@ -2,19 +2,19 @@ package com.jsontypedef.jtdcodegendemo;
 
 public enum PreferencesTitle {
 
-  @JsonProperty("MS")
-  MS,
+  @JsonProperty("MR")
+  MR,
 
   @JsonProperty("HRH")
   HRH,
+
+  @JsonProperty("MS")
+  MS,
 
   @JsonProperty("REV")
   REV,
 
   @JsonProperty("MRS")
   MRS,
-
-  @JsonProperty("MR")
-  MR,
 
 }

--- a/integration_tests/java/user/User.java
+++ b/integration_tests/java/user/User.java
@@ -1,17 +1,23 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class User {
 
   
-  @JsonProperty("labels")
-  private Map<String, String> labels;
-
-  
   @JsonProperty("preferences")
   private Preferences preferences;
+
+  
+  @JsonProperty("labels")
+  private Map<String, String> labels;
 
   
   @JsonProperty("id")
@@ -36,20 +42,20 @@ public class User {
   
 
 
-  public Map<String, String> getLabels() {
-    return labels;
-  }
-
-  public void setLabels(Map<String, String> labels) {
-    this.labels = labels;
-  }
-
   public Preferences getPreferences() {
     return preferences;
   }
 
   public void setPreferences(Preferences preferences) {
     this.preferences = preferences;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  public void setLabels(Map<String, String> labels) {
+    this.labels = labels;
   }
 
   public String getId() {

--- a/integration_tests/java/values/Values.java
+++ b/integration_tests/java/values/Values.java
@@ -1,6 +1,12 @@
 package com.jsontypedef.jtdcodegendemo;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Map;
 
 
 public class Values {

--- a/integration_tests/typescript/gamut/index.ts
+++ b/integration_tests/typescript/gamut/index.ts
@@ -14,9 +14,25 @@ export type Enum = ("bar" | "baz" | "foo");
 export type Values = {[name: string]: Value};
 
 
-export interface Element {
+export interface Value {
 
-  elementThing: any;
+  valueThing: any;
+}
+
+
+export interface DiscriminatorBar {
+
+  barThing: any;
+
+  foo: "bar";
+}
+
+
+export interface DiscriminatorBaz {
+
+  bazThing: any;
+
+  foo: "baz";
 }
 
 
@@ -46,25 +62,9 @@ export interface Type {
 }
 
 
-export interface DiscriminatorBaz {
+export interface Element {
 
-  bazThing: any;
-
-  foo: "baz";
-}
-
-
-export interface DiscriminatorBar {
-
-  barThing: any;
-
-  foo: "bar";
-}
-
-
-export interface Value {
-
-  valueThing: any;
+  elementThing: any;
 }
 
 

--- a/src/target/java/class.java.hbs
+++ b/src/target/java/class.java.hbs
@@ -1,14 +1,18 @@
 package {{package}};
 
-{{#each imports}}
-import {{this}};
-{{/each}}
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.List;
+import java.util.Map;
 
 {{#if discriminator}}
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = {{discriminator}})
   @JsonSubTypes({
     {{#each ../discriminator_variants}}
-      @JsonSubTypes.Type({{this}}.class),
+      @JsonSubTypes.Type(name = "{{json_name}}", value = {{class_name}}.class),
     {{/each}}
   })
 {{/if}}

--- a/src/target/java/mod.rs
+++ b/src/target/java/mod.rs
@@ -24,11 +24,17 @@ struct TemplateDatas {
 struct Class {
     package: String,
     discriminator: String,
-    discriminator_variants: Vec<String>,
+    discriminator_variants: Vec<DiscriminatorVariant>,
     is_abstract: bool,
     name: String,
     extends: String,
     properties: Vec<Property>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiscriminatorVariant {
+    json_name: String,
+    class_name: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -294,10 +300,13 @@ impl Target {
 
                 let mut variants = vec![];
                 for (name, schema) in mapping {
-                    variants
-                        .push(state.with_path_segment(name.clone(), &|state| {
-                            self.emit_ast(state, schema)
-                        }));
+                    let variant_class_name = state
+                        .with_path_segment(name.clone(), &|state| self.emit_ast(state, schema));
+
+                    variants.push(DiscriminatorVariant {
+                        json_name: name.clone(),
+                        class_name: variant_class_name,
+                    });
 
                     // A bit of a hack, but this step here ensures that the
                     // class generated in the previous emit_ast call immediately


### PR DESCRIPTION
This PR includes two fixes to make Java codegen work more out of the box:

1. All possible necessary includes are always imported, that way we don't need to rely on IDEs to do that work for us.
2. Fix Java discriminator codegen to rely a bit less on Jackson's magic class-name-finding stuff. In particular, with this change, we go from this:

```java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "version")
@JsonSubTypes({
    @JsonSubTypes.Type(V1.class),
    @JsonSubTypes.Type(V2.class),
})
```

To this:

```java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "version")
@JsonSubTypes({
    @JsonSubTypes.Type(name = "v1", value = V1.class),
    @JsonSubTypes.Type(name = "v2", value = V2.class),
})
```