### PR TITLE
go, ts, csharp: Improve stability of generated output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "jtd-codegen"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "Inflector",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jtd-codegen"
 description = "Generate code from JSON Typedef schemas"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 authors = ["Ulysse Carion <ulysse@segment.com>"]
 edition = "2018"

--- a/integration_tests/csharp/gamut/Discriminator.cs
+++ b/integration_tests/csharp/gamut/Discriminator.cs
@@ -24,9 +24,9 @@ namespace Jtd.JtdCodegenDemo
             {
                 return
 
-                    objectType == typeof(DiscriminatorBaz)  ||
+                    objectType == typeof(DiscriminatorBar)  ||
 
-                    objectType == typeof(DiscriminatorBar) 
+                    objectType == typeof(DiscriminatorBaz) 
 ;
             }
 
@@ -44,16 +44,16 @@ namespace Jtd.JtdCodegenDemo
                 switch (discriminatorValue)
                 {
 
-                    case "baz":
+                    case "bar":
                     {
-                        DiscriminatorBaz value = new DiscriminatorBaz();
+                        DiscriminatorBar value = new DiscriminatorBar();
                         serializer.Populate(obj.CreateReader(), value);
                         return value;
                     }
 
-                    case "bar":
+                    case "baz":
                     {
-                        DiscriminatorBar value = new DiscriminatorBar();
+                        DiscriminatorBaz value = new DiscriminatorBaz();
                         serializer.Populate(obj.CreateReader(), value);
                         return value;
                     }

--- a/integration_tests/typescript/discriminator/index.ts
+++ b/integration_tests/typescript/discriminator/index.ts
@@ -2,14 +2,6 @@
 export type Discriminator = V1 | V2;
 
 
-export interface V1User {
-
-  favoriteNumbers: number[];
-
-  id: string;
-}
-
-
 export interface V1 {
 
   user: V1User;
@@ -18,9 +10,9 @@ export interface V1 {
 }
 
 
-export interface V2User {
+export interface V1User {
 
-  favoriteNumbers: string[];
+  favoriteNumbers: number[];
 
   id: string;
 }
@@ -31,5 +23,13 @@ export interface V2 {
   user: V2User;
 
   version: "v2";
+}
+
+
+export interface V2User {
+
+  favoriteNumbers: string[];
+
+  id: string;
 }
 

--- a/integration_tests/typescript/gamut/index.ts
+++ b/integration_tests/typescript/gamut/index.ts
@@ -14,6 +14,44 @@ export type Enum = ("bar" | "baz" | "foo");
 export type Values = {[name: string]: Value};
 
 
+export interface DiscriminatorBar {
+
+  barThing: any;
+
+  foo: "bar";
+}
+
+
+export interface DiscriminatorBaz {
+
+  bazThing: any;
+
+  foo: "baz";
+}
+
+
+export interface Element {
+
+  elementThing: any;
+}
+
+
+export interface Gamut {
+
+  discriminator: Discriminator;
+
+  elements: Elements;
+
+  empty: Empty;
+
+  enum: Enum;
+
+  type: Type;
+
+  values: Values;
+}
+
+
 export interface Type {
 
   boolean: boolean;
@@ -40,46 +78,8 @@ export interface Type {
 }
 
 
-export interface DiscriminatorBaz {
-
-  bazThing: any;
-
-  foo: "baz";
-}
-
-
-export interface DiscriminatorBar {
-
-  barThing: any;
-
-  foo: "bar";
-}
-
-
-export interface Element {
-
-  elementThing: any;
-}
-
-
 export interface Value {
 
   valueThing: any;
-}
-
-
-export interface Gamut {
-
-  discriminator: Discriminator;
-
-  elements: Elements;
-
-  empty: Empty;
-
-  enum: Enum;
-
-  type: Type;
-
-  values: Values;
 }
 

--- a/integration_tests/typescript/user/index.ts
+++ b/integration_tests/typescript/user/index.ts
@@ -27,6 +27,20 @@ export interface Location {
 }
 
 /**
+ * Some preferences the user has indicated to us.
+ */
+export interface Preferences {
+  /**
+   * User preferences around do-not-track
+   */
+  doNotTrack: PreferencesDoNotTrack;
+  /**
+   * A title we should use when addressing the user formally.
+   */
+  title?: ("HRH" | "MR" | "MRS" | "MS" | "REV");
+}
+
+/**
  * Our pre-GDPR do-not-track settings
  */
 export interface PreferencesDoNotTrackV0 {
@@ -52,20 +66,6 @@ export interface PreferencesDoNotTrackV1 {
   optOutChannels: string[];
 
   version: "v1";
-}
-
-/**
- * Some preferences the user has indicated to us.
- */
-export interface Preferences {
-  /**
-   * User preferences around do-not-track
-   */
-  doNotTrack: PreferencesDoNotTrack;
-  /**
-   * A title we should use when addressing the user formally.
-   */
-  title?: ("HRH" | "MR" | "MRS" | "MS" | "REV");
 }
 
 /**

--- a/src/target/csharp/mod.rs
+++ b/src/target/csharp/mod.rs
@@ -128,6 +128,7 @@ impl super::Target for Target {
 
         for class in &mut state.data.classes {
             class.properties.sort_by_key(|p| p.name.clone());
+            class.discriminator_variants.sort_by_key(|v| v.class_name.clone());
         }
 
         for enum_ in &mut state.data.enums {

--- a/src/target/go/mod.rs
+++ b/src/target/go/mod.rs
@@ -5,7 +5,6 @@ use handlebars::Handlebars;
 use inflector::Inflector;
 use jtd::{Form, Schema};
 use serde::Serialize;
-use std::collections::HashSet;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -19,7 +18,7 @@ pub struct Target {
 #[derive(Debug, Serialize)]
 struct TemplateData {
     package: String,
-    imports: HashSet<String>,
+    imports: Vec<String>,
     aliases: Vec<TypeAlias>,
     consts: Vec<Const>,
     structs: Vec<Struct>,
@@ -111,7 +110,7 @@ impl super::Target for Target {
             self.root_name.clone(),
             TemplateData {
                 package: self.pkg_name.clone(),
-                imports: HashSet::new(),
+                imports: vec![],
                 aliases: vec![],
                 consts: vec![],
                 structs: vec![],
@@ -150,6 +149,7 @@ impl super::Target for Target {
             &Some(state.data),
             &mut out,
         )?;
+
         Ok(())
     }
 }
@@ -206,7 +206,10 @@ impl Target {
                     jtd::form::TypeValue::Uint32 => "uint32",
                     jtd::form::TypeValue::String => "string",
                     jtd::form::TypeValue::Timestamp => {
-                        state.data.imports.insert("time".to_owned());
+                        if !state.data.imports.contains(&"time".to_owned()) {
+                            state.data.imports.push("time".to_owned());
+                        }
+
                         "time.Time"
                     }
                 };
@@ -336,7 +339,9 @@ impl Target {
                 ref mapping,
                 nullable,
             }) => {
-                state.data.imports.insert("encoding/json".to_owned());
+                if !state.data.imports.contains(&"encoding/json".to_owned()) {
+                    state.data.imports.push("encoding/json".to_owned());
+                }
 
                 let tag_type = state.with_path_segment(discriminator.clone(), &|state| {
                     let tag_type = state.name();

--- a/src/target/typescript/mod.rs
+++ b/src/target/typescript/mod.rs
@@ -87,6 +87,7 @@ impl super::Target for Target {
         state.with_must_emit(true, &|state| Self::emit_ast(state, schema));
 
         state.data.aliases.sort_by_key(|a| a.name.clone());
+        state.data.structs.sort_by_key(|v| v.name.clone());
 
         for struct_ in &mut state.data.structs {
             struct_.members.sort_by_key(|v| v.name.clone());


### PR DESCRIPTION
This PR improves the stability of generated code for Go, TypeScript, and CSharp. It does this by eliminating use of unordered data structures for Handlebars rendering, and by sorting ordered data structures before passing them to handlebars.

In particular, this PR makes the following stable:

* Go `import` statements
* CSharp discriminator variants
* TypeScript interfaces