### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "jtd_codegen_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jtd_codegen_cli"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ulysse Carion <ulysse@segment.com>"]
 edition = "2018"
 


### PR DESCRIPTION
This PR bumps the CLI tool to version v0.3.0. 

There are no breaking changes from v0.2.1, but the introduction of a new target type (two of them, technically: `.rb` and `.rbs`) warrants a minor version bump.