### PR TITLE
Run each package's tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,25 @@
 on: push
 jobs:
   test:
+    strategy:
+      matrix:
+        package:
+          - jtd_codegen_cli
+          - jtd_codegen_target_csharp_system_text
+          - jtd_codegen_target_go
+          - jtd_codegen_target_java_jackson
+          - jtd_codegen_target_python
+          - jtd_codegen_target_ruby
+          - jtd_codegen_target_ruby_sig
+          - jtd_codegen_target_rust
+          - jtd_codegen_target_typescript
+          - jtd_codegen_test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: cargo test
+      - run: cargo test --package=$PACKAGE
+        env:
+          PACKAGE: ${{ matrix.package }}


### PR DESCRIPTION
This PR parallelizes tests, by running each target's tests in a separate worker. This comes at the cost of requiring us to remember to add a new target to the list whenever one is added, but the speedup from 30m to 6m is probably worth the cost.

Before: https://github.com/jsontypedef/json-typedef-codegen/actions/runs/709980353
After: https://github.com/jsontypedef/json-typedef-codegen/actions/runs/710039330