### PR TITLE
Better handling of optional properties in Rust

### DIFF
--- a/crates/core/src/target/mod.rs
+++ b/crates/core/src/target/mod.rs
@@ -87,6 +87,7 @@ pub enum Expr {
     ArrayOf(String),
     DictOf(String),
     NullableOf(String),
+    RecursiveRef(String),
 }
 
 #[derive(Debug)]

--- a/crates/target_csharp_system_text/src/lib.rs
+++ b/crates/target_csharp_system_text/src/lib.rs
@@ -125,6 +125,7 @@ impl jtd_codegen::target::Target for Target {
                 format!("IDictionary<string, {}>", sub_expr)
             }
             target::Expr::NullableOf(sub_expr) => format!("{}?", sub_expr),
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 

--- a/crates/target_go/src/lib.rs
+++ b/crates/target_go/src/lib.rs
@@ -114,6 +114,7 @@ impl jtd_codegen::target::Target for Target {
             target::Expr::ArrayOf(sub_expr) => format!("[]{}", sub_expr),
             target::Expr::DictOf(sub_expr) => format!("map[string]{}", sub_expr),
             target::Expr::NullableOf(sub_expr) => format!("*{}", sub_expr),
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 

--- a/crates/target_java_jackson/src/lib.rs
+++ b/crates/target_java_jackson/src/lib.rs
@@ -125,6 +125,7 @@ impl jtd_codegen::target::Target for Target {
                 format!("Map<String, {}>", sub_expr)
             }
             target::Expr::NullableOf(sub_expr) => sub_expr, // everything is already nullable
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 

--- a/crates/target_python/src/lib.rs
+++ b/crates/target_python/src/lib.rs
@@ -135,6 +135,7 @@ impl jtd_codegen::target::Target for Target {
 
                 format!("Optional[{}]", sub_expr)
             }
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 

--- a/crates/target_ruby/src/lib.rs
+++ b/crates/target_ruby/src/lib.rs
@@ -117,6 +117,7 @@ impl jtd_codegen::target::Target for Target {
                 format!("Hash[String, {}]", sub_expr)
             }
             target::Expr::NullableOf(sub_expr) => sub_expr,
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 

--- a/crates/target_ruby_sig/src/lib.rs
+++ b/crates/target_ruby_sig/src/lib.rs
@@ -116,6 +116,7 @@ impl jtd_codegen::target::Target for Target {
                 format!("Hash[String, {}]", sub_expr)
             }
             target::Expr::NullableOf(sub_expr) => format!("{}?", sub_expr),
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 

--- a/crates/target_typescript/src/lib.rs
+++ b/crates/target_typescript/src/lib.rs
@@ -92,6 +92,7 @@ impl jtd_codegen::target::Target for Target {
             target::Expr::ArrayOf(sub_expr) => format!("{}[]", sub_expr),
             target::Expr::DictOf(sub_expr) => format!("{{ [key: string]: {} }}", sub_expr),
             target::Expr::NullableOf(sub_expr) => format!("({} | null)", sub_expr),
+            target::Expr::RecursiveRef(sub_expr) => sub_expr,
         }
     }
 


### PR DESCRIPTION
## The problem

Currently, optional properties have their type systematically wrapped in `Option<Box<...>>` in Rust. This is not satisfying. This creates an unnecessary allocation on the heap, as well as a significant memory overhead for atomic types (especially small ones such as `i8` or `u8`).

The `Box` is actually here only to ensure that the generated Rust code will compile when recursive types are involved.

## Proposed solution

This PR introduces a detection of recursive types, and only uses `Box` for them. Any other type in optional properties is now simply wrapped in `Option<...>`.

Note that this strategy it is still overly defensive. Recursive types are wrapped in `Box` *everywhere*, including places where this would not be necessary (and not just in `Option<...>`). This could maybe be improved, but I consider that this is still better than the current situation. Of course the user can still override this with `metadata.rustType`.

This PR is still marked WIP because
- maybe it can be made a little less defensive (see above), and
- the test suite needs to be adapted to the proposed change.

But before continuing, I would like to get the maintainers opinion on that proposition ;)