### PR TITLE
Rust: Fixing Dockerfile and Cargo.toml for test cases

### DIFF
--- a/crates/target_rust/docker/Cargo.toml
+++ b/crates/target_rust/docker/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Ulysse Carion <ulysse@segment.com>"]
 edition = "2018"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-serde_json = "1"
-serde = { version = "1.0", features = ["derive"] }
+chrono = { version = "0.4.22", features = ["serde"] }
+serde_json = "1.0.83"
+serde = { version = "1.0.143", features = ["derive"] }

--- a/crates/target_rust/docker/Dockerfile
+++ b/crates/target_rust/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.49
+FROM rust:1.63
 
 ARG MAIN
 

--- a/crates/target_rust/docker/Dockerfile
+++ b/crates/target_rust/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM rust:1.63
 
 ARG MAIN
@@ -13,5 +14,5 @@ COPY /main.rs /work/src/main.rs
 COPY /gen /work/src/jtd_codegen_e2e/
 RUN sed -i -e "s/MAIN/$MAIN/g" /work/src/main.rs
 
-RUN cargo build
+RUN --mount=type=cache,target="${HOME}/.cargo" cargo build
 ENTRYPOINT target/debug/jtd_e2e_test


### PR DESCRIPTION
This solves issue: https://github.com/jsontypedef/json-typedef-codegen/issues/57

# Solution

I've pinned the dependencies at a version that works today and sets the tested Rust version to one that is also current.

# Extra Credit

I've also added docker buildkit into the mix so the cargo dependencies are shared across each of the test-cases and saves some testing time. I don't know if there is any CI/CD in place already, but if the Docker version running is current this should be non-breaking