### PR TITLE
Updating rust output to be language idomatic

### DIFF
--- a/crates/target_rust/output/custom_overrides/mod.rs
+++ b/crates/target_rust/output/custom_overrides/mod.rs
@@ -9,20 +9,20 @@ pub struct RootOverrideTypeDiscriminatorBaz {}
 #[derive(Serialize, Deserialize)]
 pub struct Root {
     #[serde(rename = "override_elements_container")]
-    pub overrideElementsContainer: Vec<String>,
+    pub override_elements_container: Vec<String>,
 
     #[serde(rename = "override_type_discriminator")]
-    pub overrideTypeDiscriminator: serde_json::Value,
+    pub override_type_discriminator: serde_json::Value,
 
     #[serde(rename = "override_type_enum")]
-    pub overrideTypeEnum: serde_json::Value,
+    pub override_type_enum: serde_json::Value,
 
     #[serde(rename = "override_type_expr")]
-    pub overrideTypeExpr: serde_json::Value,
+    pub override_type_expr: serde_json::Value,
 
     #[serde(rename = "override_type_properties")]
-    pub overrideTypeProperties: serde_json::Value,
+    pub override_type_properties: serde_json::Value,
 
     #[serde(rename = "override_values_container")]
-    pub overrideValuesContainer: HashMap<String, String>,
+    pub override_values_container: HashMap<String, String>,
 }

--- a/crates/target_rust/output/description/mod.rs
+++ b/crates/target_rust/output/description/mod.rs
@@ -38,11 +38,11 @@ pub struct RootPropertiesWithDescription {}
 pub struct Root {
     /// A description for discriminator
     #[serde(rename = "discriminator_with_description")]
-    pub discriminatorWithDescription: RootDiscriminatorWithDescription,
+    pub discriminator_with_description: RootDiscriminatorWithDescription,
 
     /// A description for enum
     #[serde(rename = "enum_with_description")]
-    pub enumWithDescription: RootEnumWithDescription,
+    pub enum_with_description: RootEnumWithDescription,
 
     /// Whereas disregard and contempt for human rights have resulted in
     /// barbarous acts which have outraged the conscience of mankind, and the
@@ -50,19 +50,19 @@ pub struct Root {
     /// and belief and freedom from fear and want has been proclaimed as the
     /// highest aspiration of the common people,
     #[serde(rename = "long_description")]
-    pub longDescription: String,
+    pub long_description: String,
 
     /// A description for properties
     #[serde(rename = "properties_with_description")]
-    pub propertiesWithDescription: RootPropertiesWithDescription,
+    pub properties_with_description: RootPropertiesWithDescription,
 
     /// A description for ref
     #[serde(rename = "ref_with_description")]
-    pub refWithDescription: Baz,
+    pub ref_with_description: Baz,
 
     /// A description for string
     #[serde(rename = "string_with_description")]
-    pub stringWithDescription: String,
+    pub string_with_description: String,
 }
 
 /// A description for a definition

--- a/crates/target_rust/output/empty_and_nonascii_properties/mod.rs
+++ b/crates/target_rust/output/empty_and_nonascii_properties/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct Root {
     #[serde(rename = "")]
-    pub defaultName: String,
+    pub default_name: String,
 
     #[serde(rename = "$foo")]
     pub foo: String,
@@ -17,14 +17,14 @@ pub struct Root {
     pub foo1: String,
 
     #[serde(rename = "foo\nbar")]
-    pub fooBar: String,
+    pub foo_bar: String,
 
     #[serde(rename = "foo bar")]
-    pub fooBar0: String,
+    pub foo_bar0: String,
 
     #[serde(rename = "foo0bar")]
     pub foo0bar: String,
 
     #[serde(rename = "foo﷽bar")]
-    pub fooBar1: String,
+    pub foo_bar1: String,
 }

--- a/crates/target_rust/output/enum_collisions/mod.rs
+++ b/crates/target_rust/output/enum_collisions/mod.rs
@@ -32,5 +32,5 @@ pub struct Root {
     pub foo: RootFoo,
 
     #[serde(rename = "foo_bar")]
-    pub fooBar: RootFooBar0,
+    pub foo_bar: RootFooBar0,
 }

--- a/crates/target_rust/output/initialisms/mod.rs
+++ b/crates/target_rust/output/initialisms/mod.rs
@@ -20,14 +20,14 @@ pub struct Root {
     pub id: String,
 
     #[serde(rename = "nested_id_initialism")]
-    pub nestedIdInitialism: RootNestedIdInitialism,
+    pub nested_id_initialism: RootNestedIdInitialism,
 
     #[serde(rename = "utf8")]
     pub utf8: String,
 
     #[serde(rename = "word_with_embedded_id_initialism")]
-    pub wordWithEmbeddedIdInitialism: String,
+    pub word_with_embedded_id_initialism: String,
 
     #[serde(rename = "word_with_trailing_initialism_id")]
-    pub wordWithTrailingInitialismId: String,
+    pub word_with_trailing_initialism_id: String,
 }

--- a/crates/target_rust/output/nullable_references/mod.rs
+++ b/crates/target_rust/output/nullable_references/mod.rs
@@ -5,22 +5,22 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct Root {
     #[serde(rename = "notnull_ref_notnull_string")]
-    pub notnullRefNotnullString: NotnullRefNotnullString,
+    pub notnull_ref_notnull_string: NotnullRefNotnullString,
 
     #[serde(rename = "notnull_ref_null_string")]
-    pub notnullRefNullString: NotnullRefNullString,
+    pub notnull_ref_null_string: NotnullRefNullString,
 
     #[serde(rename = "notnull_string")]
-    pub notnullString: NotnullString,
+    pub notnull_string: NotnullString,
 
     #[serde(rename = "null_ref_notnull_string")]
-    pub nullRefNotnullString: NullRefNotnullString,
+    pub null_ref_notnull_string: NullRefNotnullString,
 
     #[serde(rename = "null_ref_null_string")]
-    pub nullRefNullString: NullRefNullString,
+    pub null_ref_null_string: NullRefNullString,
 
     #[serde(rename = "null_string")]
-    pub nullString: NullString,
+    pub null_string: NullString,
 }
 
 pub type NotnullRefNotnullString = NotnullString;

--- a/crates/target_rust/output/type_collisions/mod.rs
+++ b/crates/target_rust/output/type_collisions/mod.rs
@@ -26,5 +26,5 @@ pub struct Root {
     pub foo: RootFoo,
 
     #[serde(rename = "foo_bar")]
-    pub fooBar: RootFooBar0,
+    pub foo_bar: RootFooBar0,
 }

--- a/crates/target_rust/src/lib.rs
+++ b/crates/target_rust/src/lib.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref FIELD_NAMING_CONVENTION: Box<dyn inflect::Inflector + Send + Sync> =
         Box::new(inflect::KeywordAvoidingInflector::new(
             KEYWORDS.clone(),
-            inflect::TailInflector::new(inflect::Case::camel_case())
+            inflect::TailInflector::new(inflect::Case::snake_case())
         ));
     static ref ENUM_MEMBER_NAMING_CONVENTION: Box<dyn inflect::Inflector + Send + Sync> =
         Box::new(inflect::KeywordAvoidingInflector::new(


### PR DESCRIPTION
Struct fields should be snake_case, but they were accidentaly set to
camelCase.

This resolves issue https://github.com/jsontypedef/json-typedef-codegen/issues/32, but will require https://github.com/jsontypedef/json-typedef-codegen/pull/58 to be merged first in order to actually validate the code change is correct