### PR TITLE
feat(target_typescript): add support for additionalProperties

### DIFF
--- a/crates/target_typescript/output/geojson/index.ts
+++ b/crates/target_typescript/output/geojson/index.ts
@@ -172,6 +172,7 @@ export interface GeojsonObjectGeometryCollection {
   type: "GeometryCollection";
   geometries: GeojsonObject[];
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**
@@ -182,6 +183,7 @@ export interface GeojsonObjectLineString {
   type: "LineString";
   coordinates: Position[];
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**
@@ -192,6 +194,7 @@ export interface GeojsonObjectMultiLineString {
   type: "MultiLineString";
   coordinates: Position[];
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**
@@ -202,6 +205,7 @@ export interface GeojsonObjectMultiPoint {
   type: "MultiPoint";
   coordinates: Position[];
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**
@@ -212,6 +216,7 @@ export interface GeojsonObjectMultiPolygon {
   type: "MultiPolygon";
   coordinates: LinearRing[];
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**
@@ -221,6 +226,7 @@ export interface GeojsonObjectPoint {
   type: "Point";
   coordinates: Position;
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**
@@ -231,6 +237,7 @@ export interface GeojsonObjectPolygon {
   type: "Polygon";
   coordinates: LinearRing[];
   bbox?: BoundingBox;
+  [x: string]: unknown;
 }
 
 /**

--- a/crates/target_typescript/src/lib.rs
+++ b/crates/target_typescript/src/lib.rs
@@ -161,7 +161,7 @@ impl jtd_codegen::target::Target for Target {
             target::Item::Struct {
                 metadata,
                 name,
-                has_additional: _,
+                has_additional,
                 fields,
             } => {
                 if let Some(s) = metadata.get("typescriptType").and_then(|v| v.as_str()) {
@@ -194,6 +194,9 @@ impl jtd_codegen::target::Target for Target {
                             field.type_
                         )?;
                     }
+                }
+                if has_additional {
+                    writeln!(out, "  [x: string]: unknown;")?;
                 }
                 writeln!(out, "}}")?;
 
@@ -231,6 +234,7 @@ impl jtd_codegen::target::Target for Target {
                 name,
                 tag_json_name,
                 tag_value,
+                has_additional,
                 fields,
                 ..
             } => {
@@ -265,6 +269,9 @@ impl jtd_codegen::target::Target for Target {
                             field.type_
                         )?;
                     }
+                }
+                if has_additional {
+                    writeln!(out, "  [x: string]: unknown;")?;
                 }
                 writeln!(out, "}}")?;
 


### PR DESCRIPTION
Add support for additionalProperties in typescript output target.

### Example

JSON Typedef:

```json
{
    "properties": {
        "name": { "type": "string" },
        "isAdmin": { "type": "boolean" }
    },
    "additionalProperties": true
}
```

Generated TypeScript code:

```typescript
export interface Root {
  isAdmin: boolean;
  name: string;
  [x: string]: unknown;
}
```